### PR TITLE
Fix pandas FutureWarning in twins dataset loading

### DIFF
--- a/alg/ganite/ganite/datasets/dataset_twins.py
+++ b/alg/ganite/ganite/datasets/dataset_twins.py
@@ -106,6 +106,7 @@ def preprocess(
         df[feat] = df[feat].apply(lambda x: df[feat].mode()[0] if x in [8, 9] else x)
 
     for feat in other_list:
+        df[feat] = df[feat].astype(float)
         df.loc[df[feat] == 99, feat] = df.loc[df[feat] != 99, feat].mean()
 
     df_features = df[con_list + bin_list]


### PR DESCRIPTION
Fix pandas FutureWarning in twins dataset loading

The imputation logic for the 'twins' dataset was causing a FutureWarning due
to assigning a float (the mean) into an int64 column. This will raise a
TypeError in future versions of pandas.

Explicitly cast the relevant columns to float64 before performing the mean 
imputation to ensure type compatibility.